### PR TITLE
130 - allow trailing whitespace for complex messages

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -375,6 +375,18 @@ func TestParseComplexMessage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "trailing whitespace",
+			input: "{{Hello, { |literal| } World!}}\n\t ",
+			want: ComplexMessage{
+				Declarations: nil,
+				ComplexBody: QuotedPattern{
+					Text("Hello, "),
+					Expression{Operand: QuotedLiteral("literal")},
+					Text(" World!"),
+				},
+			},
+		},
 		//nolint:dupword
 		{
 			name: "all declarations",

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -377,13 +377,11 @@ func TestParseComplexMessage(t *testing.T) {
 		},
 		{
 			name:  "trailing whitespace",
-			input: "{{Hello, { |literal| } World!}}\n\t ",
+			input: "{{Hello, World!}}\n\t ",
 			want: ComplexMessage{
 				Declarations: nil,
 				ComplexBody: QuotedPattern{
-					Text("Hello, "),
-					Expression{Operand: QuotedLiteral("literal")},
-					Text(" World!"),
+					Text("Hello, World!"),
 				},
 			},
 		},
@@ -748,7 +746,7 @@ no no {{Hello!}}`,
 
 			// Check that AST message is equal to expected one.
 			if test.want.String() != got.Message.String() {
-				t.Errorf("want %s, got %s", test.want, test.want)
+				t.Errorf("want %s, got %s", test.want, got.Message)
 			}
 
 			// Check that AST message converted back to string is equal to input.


### PR DESCRIPTION
Parser already supports trailing whitespaces in the complex message.

I added a unit test to assert this behaviour.