### PR TITLE
Formatted zeros

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"go.expect.digital/mf2/parse"
@@ -564,7 +565,7 @@ func toLiteral(value any) parse.Literal {
 	default:
 		s = fmt.Sprint(value)
 	case int:
-		return parse.NumberLiteral(float64(v))
+		return parse.NumberLiteral(strconv.Itoa(v))
 	case string:
 		s = v
 	}

--- a/mf2wg_test.go
+++ b/mf2wg_test.go
@@ -22,12 +22,6 @@ func init() {
 	//nolint:lll
 	failing = []string{
 		"TestMF2WG/.message-format-wg/test/tests/functions/datetime.json/{|2006-01-02T15:04:06|_:datetime_year=numeric_month=|2-digit|}",
-
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/{0E-1}#01",
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/{0E1}",
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/{0E-1}",
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/{0e1}",
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/{-0}",
 	}
 }
 

--- a/parse/ast.go
+++ b/parse/ast.go
@@ -2,7 +2,6 @@ package parse
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -208,10 +207,10 @@ func (NameLiteral) literal()    {}
 func (NameLiteral) value()      {}
 func (NameLiteral) variantKey() {}
 
-type NumberLiteral float64
+type NumberLiteral string
 
 // String returns MF2 formatted string.
-func (l NumberLiteral) String() string { return strconv.FormatFloat(float64(l), 'f', -1, 64) }
+func (l NumberLiteral) String() string { return string(l) }
 
 func (NumberLiteral) node()       {}
 func (NumberLiteral) literal()    {}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -974,11 +974,11 @@ func (p *parser) parseLiteral() (Literal, error) {
 			return nil, fmt.Errorf("number literal: %w", err)
 		}
 
-		return NumberLiteral(num), nil
+		return NumberLiteral(itm.val), nil
 	case itemQuotedLiteral:
-		return QuotedLiteral(p.current().val), nil
+		return QuotedLiteral(itm.val), nil
 	case itemUnquotedLiteral:
-		return NameLiteral(p.current().val), nil
+		return NameLiteral(itm.val), nil
 	}
 }
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -83,7 +83,7 @@ func TestParseSimpleMessage(t *testing.T) {
 						},
 						Options: []Option{
 							{
-								Value: NumberLiteral(-3.14),
+								Value: NumberLiteral("-3.14"),
 								Identifier: Identifier{
 									Namespace: "",
 									Name:      "option1",
@@ -129,7 +129,7 @@ func TestParseSimpleMessage(t *testing.T) {
 			input: "Hello, { 1e3 }  World!",
 			want: SimpleMessage{
 				Text("Hello, "),
-				Expression{Operand: NumberLiteral(1e3)},
+				Expression{Operand: NumberLiteral("1e3")},
 				Text("  World!"),
 			},
 		},
@@ -173,14 +173,14 @@ func TestParseSimpleMessage(t *testing.T) {
 						},
 						Options: []Option{
 							{
-								Value: NumberLiteral(-1),
+								Value: NumberLiteral("-1"),
 								Identifier: Identifier{
 									Namespace: "ns1",
 									Name:      "option1",
 								},
 							},
 							{
-								Value: NumberLiteral(+1),
+								Value: NumberLiteral("1"),
 								Identifier: Identifier{
 									Namespace: "ns2",
 									Name:      "option2",
@@ -228,7 +228,7 @@ func TestParseSimpleMessage(t *testing.T) {
 						},
 						Options: []Option{
 							{
-								Value: NumberLiteral(999),
+								Value: NumberLiteral("999"),
 								Identifier: Identifier{
 									Namespace: "namespace",
 									Name:      "option999",
@@ -269,7 +269,7 @@ func TestParseSimpleMessage(t *testing.T) {
 						},
 						{
 							Identifier: Identifier{Name: "k"},
-							Value:      NumberLiteral(2),
+							Value:      NumberLiteral("2"),
 						},
 						{
 							Identifier: Identifier{Namespace: "l", Name: "l"},
@@ -418,14 +418,14 @@ func TestParseComplexMessage(t *testing.T) {
 							},
 						},
 						Attributes: []Attribute{
-							{Identifier: Identifier{Name: "c"}, Value: NumberLiteral(1)},
-							{Identifier: Identifier{Name: "d"}, Value: NumberLiteral(2)},
+							{Identifier: Identifier{Name: "c"}, Value: NumberLiteral("1")},
+							{Identifier: Identifier{Name: "d"}, Value: NumberLiteral("2")},
 						},
 					},
 					// .local $local1={1}
 					LocalDeclaration{
 						Variable:   Variable("local1"),
-						Expression: Expression{Operand: NumberLiteral(1)},
+						Expression: Expression{Operand: NumberLiteral("1")},
 					},
 					// .local $local2={|2| ^private @a @b=2}
 					LocalDeclaration{
@@ -438,7 +438,7 @@ func TestParseComplexMessage(t *testing.T) {
 							},
 							Attributes: []Attribute{
 								{Identifier: Identifier{Name: "a"}},
-								{Identifier: Identifier{Name: "b"}, Value: NumberLiteral(2)},
+								{Identifier: Identifier{Name: "b"}, Value: NumberLiteral("2")},
 							},
 						},
 					},
@@ -518,7 +518,7 @@ func TestParseComplexMessage(t *testing.T) {
 					},
 					Variants: []Variant{
 						{
-							Keys: []VariantKey{NumberLiteral(1)},
+							Keys: []VariantKey{NumberLiteral("1")},
 							QuotedPattern: QuotedPattern{
 								Text("Hello "),
 								Expression{Operand: Variable("variable")},
@@ -555,7 +555,7 @@ func TestParseComplexMessage(t *testing.T) {
 					},
 					Variants: []Variant{
 						{
-							Keys: []VariantKey{NumberLiteral(1)},
+							Keys: []VariantKey{NumberLiteral("1")},
 							QuotedPattern: QuotedPattern{
 								Text("Hello "),
 								Expression{Operand: Variable("variable")},
@@ -592,7 +592,7 @@ func TestParseComplexMessage(t *testing.T) {
 					},
 					Variants: []Variant{
 						{
-							Keys: []VariantKey{NumberLiteral(1)},
+							Keys: []VariantKey{NumberLiteral("1")},
 							QuotedPattern: QuotedPattern{
 								Text("Hello "),
 								Expression{Operand: Variable("variable")},

--- a/template/template.go
+++ b/template/template.go
@@ -424,7 +424,7 @@ func (e *executer) resolveValue(v ast.Value) (any, error) {
 	case ast.NameLiteral:
 		return string(v), nil
 	case ast.NumberLiteral:
-		return float64(v), nil
+		return string(v), nil
 	case ast.Variable:
 		val, ok := e.variables[string(v)]
 		if !ok {


### PR DESCRIPTION
Originally `NumberLiteral` was float64 type, but the documentation says: 
 > [..] a literal value with no annotation is always treated as a string. To represent values that are not strings as a literal, an annotation needs to be provided[.]

https://github.com/unicode-org/message-format-wg/blob/132d9c326271ce552cb485e07223f592fa51593e/spec/formatting.md?plain=1#L157-L160

Now the annotation function has to convert the operand into numeric type if needed.