### PR TITLE
211 - lex start

### DIFF
--- a/mf2wg_test.go
+++ b/mf2wg_test.go
@@ -22,9 +22,6 @@ func init() {
 	//nolint:lll
 	failing = []string{
 		"TestMF2WG/.message-format-wg/test/tests/functions/datetime.json/{|2006-01-02T15:04:06|_:datetime_year=numeric_month=|2-digit|}",
-
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/__{{}}__",
-		"TestMF2WG/.message-format-wg/test/tests/syntax.json/_.input{$x}{{}}_",
 	}
 }
 

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -151,7 +151,7 @@ func lex(input string) *lexer {
 // See ".message-format-wg/spec/message.abnf".
 type lexer struct {
 	input     string
-	item      item     // previous item or start char with optional start whitespaces in simple message
+	item      item     // previous item or start char with optional preceding whitespaces in simple message
 	prevType  itemType // previous non-whitespace item type
 	pos, line int
 
@@ -246,7 +246,7 @@ type stateFn func(*lexer) stateFn
 
 // lexStart is the state function to lex the start of the MF2.
 func lexStart(l *lexer) stateFn {
-	// Whitespaces at the start. When simple message, last char is start char of the simple message.
+	// Whitespaces at the start. When simple message, it is start char with optional preceding whitespaces.
 	sb := new(strings.Builder)
 
 	complexItem := func() stateFn {
@@ -304,7 +304,7 @@ func lexStart(l *lexer) stateFn {
 func lexPattern(l *lexer) stateFn {
 	sb := new(strings.Builder)
 
-	// write preceding whitespace and start character if simple message.
+	// write start character with optional preceding whitespaces if simple message.
 	if l.prevType == itemUnknown && l.item.typ == itemText {
 		sb.WriteString(l.item.val)
 	}

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -273,7 +273,7 @@ func lexStart(l *lexer) stateFn {
 
 		switch {
 		default:
-			return l.emitErrorf(`unexpected start char "%s" in message`, string(r))
+			return l.emitErrorf(`unexpected start char "%s"`, string(r))
 		case isWhitespace(r):
 			sb.WriteRune(r)
 		case isSimpleStart(r):

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -19,6 +19,11 @@ func Test_lex(t *testing.T) {
 			want:  []item{mk(itemEOF, "")},
 		},
 		{
+			name:  "whitespace simple message",
+			input: " ",
+			want:  []item{mk(itemText, " "), mk(itemEOF, "")},
+		},
+		{
 			name:  "text",
 			input: `escaped text: \\ \} \{`,
 			want: []item{
@@ -30,7 +35,7 @@ func Test_lex(t *testing.T) {
 			name:  "unescaped }",
 			input: `}`,
 			want: []item{
-				mkErr("unescaped } in pattern"),
+				mkErr(`unexpected start char "}" in message`),
 			},
 		},
 		{
@@ -534,6 +539,49 @@ func Test_lex(t *testing.T) {
 				mk(itemUnquotedLiteral, "b"),
 				mk(itemExpressionClose, "}"),
 				//
+				mk(itemEOF, ""),
+			},
+		},
+		{
+			name:  "head and tail whitespaces",
+			input: "  {{}}  ",
+			want: []item{
+				mk(itemWhitespace, "  "),
+				mk(itemQuotedPatternOpen, "{{"),
+				mk(itemQuotedPatternClose, "}}"),
+				mk(itemWhitespace, "  "),
+				mk(itemEOF, ""),
+			},
+		},
+		{
+			name:  "whitespace with declarations",
+			input: "\t.local $foo =bar {{}}\n",
+			want: []item{
+				mk(itemWhitespace, "\t"),
+				mk(itemLocalKeyword, "local"),
+				mk(itemWhitespace, " "),
+				mk(itemVariable, "foo"),
+				mk(itemWhitespace, " "),
+				mk(itemOperator, "="),
+				mk(itemUnquotedLiteral, "bar"),
+				mk(itemWhitespace, " "),
+				mk(itemQuotedPatternOpen, "{{"),
+				mk(itemQuotedPatternClose, "}}"),
+				mk(itemWhitespace, "\n"),
+				mk(itemEOF, ""),
+			},
+		},
+		{
+			name:  "no whitespace in simple message, unless inside expression",
+			input: "  { |simple| }  ",
+			want: []item{
+				mk(itemText, "  "),
+				mk(itemExpressionOpen, "{"),
+				mk(itemWhitespace, " "),
+				mk(itemQuotedLiteral, "simple"),
+				mk(itemWhitespace, " "),
+				mk(itemExpressionClose, "}"),
+				mk(itemText, "  "),
 				mk(itemEOF, ""),
 			},
 		},

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -24,10 +24,10 @@ func Test_lex(t *testing.T) {
 			want:  []item{mk(itemText, " "), mk(itemEOF, "")},
 		},
 		{
-			name:  "text",
-			input: `escaped text: \\ \} \{`,
+			name:  "escaped characters",
+			input: `\\ \} \{ \|`,
 			want: []item{
-				mk(itemText, `escaped text: \ } {`),
+				mk(itemText, `\ } { |`),
 				mk(itemEOF, ""),
 			},
 		},

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -35,7 +35,7 @@ func Test_lex(t *testing.T) {
 			name:  "unescaped }",
 			input: `}`,
 			want: []item{
-				mkErr(`unexpected start char "}" in message`),
+				mkErr(`unexpected start char "}"`),
 			},
 		},
 		{

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -602,6 +602,12 @@ func assertItems(t *testing.T, want []item, l *lexer) {
 
 	got := make([]lexer, 0, len(want))
 
+	logN := func(n int) {
+		for i := range n {
+			logItem(t, want[i], got[i])
+		}
+	}
+
 	// collect all lexer states
 
 	for {
@@ -621,6 +627,7 @@ func assertItems(t *testing.T, want []item, l *lexer) {
 
 	for i, wantItem := range want {
 		if i >= len(got) {
+			logN(i)
 			t.Fatalf("want %v, got nothing", wantItem)
 		}
 
@@ -628,18 +635,16 @@ func assertItems(t *testing.T, want []item, l *lexer) {
 
 		if wantItem.typ == itemError {
 			if wantItem.err == nil || gotItem.err == nil || wantItem.err.Error() != gotItem.err.Error() {
-				t.Errorf(`want error '%v', got '%v'`, wantItem.err, gotItem.err)
+				logN(i + 1)
+				t.Fatalf(`want error '%v', got '%v'`, wantItem.err, gotItem.err)
 			}
 
 			return
 		}
 
 		if wantItem != gotItem {
-			t.Errorf(`want '%v', got '%v'`, wantItem, gotItem)
-
-			for j := range i + 1 {
-				logItem(t, want[j], got[j])
-			}
+			logN(i + 1)
+			t.Fatalf(`want '%v', got '%v'`, wantItem, gotItem)
 		}
 	}
 }

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -654,7 +654,7 @@ func BenchmarkLex(b *testing.B) {
 	var itm item
 
 	for range b.N {
-		lexer := lex(".input {$foo :number} .local $bar = {$foo} .match {$bar} one {{one}} * {{other}}")
+		lexer := lex("  .input {$foo :number} .local $bar = {$foo} .match {$bar} one {{one}} * {{other}}  ")
 
 		for {
 			itm = lexer.nextItem()

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -92,7 +92,7 @@ func (p *parser) collect() error {
 
 // isComplexMessage returns true if first token is one of the complex message tokens.
 func (p *parser) isComplexMessage() bool {
-	switch p.items[0].typ {
+	switch p.peekNonWS().typ {
 	default:
 		return false
 	case itemInputKeyword, itemLocalKeyword, itemMatchKeyword, itemReservedKeyword, itemQuotedPatternOpen:

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -802,7 +802,7 @@ func BenchmarkParse(b *testing.B) {
 	var tree AST
 
 	for range b.N {
-		tree, _ = Parse(".input {$foo :number} .local $bar = {$foo} .match {$bar} one {{one}} * {{other}}")
+		tree, _ = Parse("  .input {$foo :number} .local $bar = {$foo} .match {$bar} one {{one}} * {{other}}  ")
 	}
 
 	runtime.KeepAlive(tree)


### PR DESCRIPTION
* lex the start
* handle whitespaces at the beginning and the end

Fixes #211 

```
➜  parse git:(211-lex-start) ✗ benchstat a.txt b.txt
goos: darwin
goarch: arm64
pkg: go.expect.digital/mf2/parse
cpu: Apple M2 Max
                         │    a.txt    │               b.txt                │
                         │   sec/op    │   sec/op     vs base               │
ComplexMessage_String-12   3.078µ ± 1%   3.134µ ± 1%  +1.84% (p=0.000 n=10)
Lex-12                     1.503µ ± 0%   1.581µ ± 1%  +5.19% (p=0.000 n=10)
Parse-12                   3.199µ ± 1%   3.334µ ± 2%  +4.22% (p=0.000 n=10)
geomean                    2.455µ        2.547µ       +3.74%

                         │    a.txt     │                 b.txt                 │
                         │     B/op     │     B/op      vs base                 │
ComplexMessage_String-12   20.33Ki ± 0%   20.33Ki ± 0%       ~ (p=1.000 n=10) ¹
Lex-12                       528.0 ± 0%     528.0 ± 0%       ~ (p=1.000 n=10) ¹
Parse-12                   7.000Ki ± 0%   7.000Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                    4.186Ki        4.186Ki       +0.00%
¹ all samples are equal

                         │   a.txt    │                b.txt                │
                         │ allocs/op  │ allocs/op   vs base                 │
ComplexMessage_String-12   43.00 ± 0%   43.00 ± 0%       ~ (p=1.000 n=10) ¹
Lex-12                     29.00 ± 0%   29.00 ± 0%       ~ (p=1.000 n=10) ¹
Parse-12                   59.00 ± 0%   59.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    41.90        41.90       +0.00%
¹ all samples are equal
```