### PR TITLE
bump golangci-lint to v1.60.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.60.2

--- a/mf2wg_test.go
+++ b/mf2wg_test.go
@@ -81,6 +81,10 @@ func run(t *testing.T, test Test) {
 		options = append(options, template.WithLocale(*test.Locale))
 	}
 
+	if test.Description != "" {
+		t.Log(test.Description)
+	}
+
 	templ, err := template.New(options...).Parse(test.Src)
 	// The implementation returns error in two places:
 	// - when parsing the template
@@ -125,6 +129,8 @@ type Tests struct {
 type Test struct {
 	// The MF2 message to be tested.
 	Src string `json:"src"`
+	// Information about the test scenario.
+	Description string `json:"description"`
 	// The locale to use for formatting. Defaults to 'en-US'.
 	Locale *language.Tag `json:"locale"`
 	// Parameters to pass in to the formatter for resolving external variables.


### PR DESCRIPTION
Also, log MF2 test description.