### PR TITLE
bump golangci-lint to v1.60.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.2
+          version: v1.60.3

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# "go test -bench" output
+*.txt
 
 # Go workspace file
 go.work


### PR DESCRIPTION
Also, ignore _*.txt_ files - output of _go test -bench_.