### PR TITLE
re-use text escaper

### DIFF
--- a/parse/ast.go
+++ b/parse/ast.go
@@ -120,7 +120,11 @@ func (m ComplexMessage) message() {}
 
 type Text string
 
-// text-escape = backslash ( backslash / "{" / "}" ).
+// textEscaper escapes characters by adding backslashes.
+//
+// ABNF:
+//
+//	escaped-char = backslash ( backslash / "{" / "|" / "}" )
 var textEscaper = strings.NewReplacer(
 	`\`, `\\`,
 	`{`, `\{`,

--- a/parse/ast.go
+++ b/parse/ast.go
@@ -120,16 +120,17 @@ func (m ComplexMessage) message() {}
 
 type Text string
 
+// text-escape = backslash ( backslash / "{" / "}" ).
+var textEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`{`, `\{`,
+	`}`, `\}`,
+	`|`, `\|`,
+)
+
 // String returns MF2 formatted string.
 func (t Text) String() string {
-	// text-escape = backslash ( backslash / "{" / "}" )
-	r := strings.NewReplacer(
-		`\`, `\\`,
-		`{`, `\{`,
-		`}`, `\}`,
-	)
-
-	return r.Replace(string(t))
+	return textEscaper.Replace(string(t))
 }
 
 func (Text) node()        {}


### PR DESCRIPTION
```console
$ benchstat a.txt b.txt                                           
goos: darwin
goarch: arm64
pkg: go.expect.digital/mf2/parse
cpu: Apple M2 Max
                         │    a.txt     │                b.txt                │
                         │    sec/op    │   sec/op     vs base                │
ComplexMessage_String-12   4073.5n ± 1%   883.9n ± 1%  -78.30% (p=0.000 n=10)

                         │    a.txt     │               b.txt                │
                         │     B/op     │    B/op     vs base                │
ComplexMessage_String-12   27816.0 ± 0%   776.0 ± 0%  -97.21% (p=0.000 n=10)

                         │   a.txt    │               b.txt                │
                         │ allocs/op  │ allocs/op   vs base                │
ComplexMessage_String-12   61.00 ± 0%   33.00 ± 0%  -45.90% (p=0.000 n=10)
```