### PR TITLE
improve lexing unquoted and number literals

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -367,7 +367,7 @@ func lexComplexMessage(l *lexer) stateFn {
 
 		switch {
 		default:
-			return l.emitErrorf(`unknown character "%c" in complex message`, r)
+			return l.emitErrorf(`bad character "%c" in complex message`, r)
 		case r == '.':
 			input := l.input[l.end:]
 
@@ -423,9 +423,10 @@ func lexComplexMessage(l *lexer) stateFn {
 			l.backup()
 
 			return lexQuotedLiteral(l)
-		case isName(r):
-			l.backup()
-			return lexUnquotedOrNumberLiteral(l)
+		case isNameStart(r):
+			return lexUnquotedLiteral(l)
+		case r == '-' || '0' <= r && r <= '9':
+			return lexNumberLiteral(l)
 		case r == eof:
 			return nil
 		}
@@ -436,9 +437,7 @@ func lexComplexMessage(l *lexer) stateFn {
 func lexExpr(l *lexer) stateFn {
 	switch r := l.next(); {
 	default:
-		l.backup()
-
-		return lexUnquotedOrNumberLiteral(l)
+		return l.emitErrorf(`bad character "%c" in expression`, r)
 	case r == variablePrefix:
 		l.start++ // skip $
 		return lexName(l, itemVariable)
@@ -491,6 +490,10 @@ func lexExpr(l *lexer) stateFn {
 		return lexIdentifier(l, itemOption)
 	case r == '=':
 		return l.emit(itemOperator)
+	case isNameStart(r):
+		return lexUnquotedLiteral(l)
+	case r == '-' || '0' <= r && r <= '9':
+		return lexNumberLiteral(l)
 	case r == eof:
 		return l.emitErrorf("unexpected eof in expression")
 	}
@@ -525,35 +528,59 @@ func lexQuotedLiteral(l *lexer) stateFn {
 	}
 }
 
-// lexUnquotedOrNumberLiteral is the state function for lexing names.
-//
-// TODO(jhorsts): unquoted literal (name) MUST start with name start character.
-func lexUnquotedOrNumberLiteral(l *lexer) stateFn {
-	var hasPlus bool
+// lexUnquotedLiteral is the state function for lexing unquoted literals.
+// The first character is already lexed.
+func lexUnquotedLiteral(l *lexer) stateFn {
+	for {
+		r := l.next()
 
-	for r := l.next(); isName(r) || r == '+'; r = l.next() {
-		if r == '+' {
-			hasPlus = true
+		switch {
+		default:
+			l.backup()
+
+			return l.emit(itemUnquotedLiteral)
+		case isName(r): // noop
+		case r == eof:
+			return l.emit(itemUnquotedLiteral)
 		}
 	}
+}
 
-	l.backup()
+// lexNumberLiteral is the state function for lexing number literals.
+// The first character is already lexed.
+//
+// ABNF:
+//
+//	number-literal   = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
+func lexNumberLiteral(l *lexer) stateFn {
+	emit := func() stateFn {
+		var number float64
 
-	var number float64
+		val := l.val()
 
-	if err := json.Unmarshal([]byte(l.val()), &number); err == nil {
+		if err := json.Unmarshal([]byte(val), &number); err != nil {
+			return l.emitErrorf(`bad number literal "%s"`, val)
+		}
+
 		return l.emit(itemNumberLiteral)
 	}
 
-	// "+" is not valid unquoted literal character
-	if hasPlus {
-		return l.emitErrorf(`invalid unquoted literal "%s"`, l.val())
-	}
+	for {
+		r := l.next()
 
-	return l.emit(itemUnquotedLiteral)
+		switch r {
+		default:
+			l.backup()
+			return emit()
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'e', '.', '-', '+': // noop
+		case eof:
+			return emit()
+		}
+	}
 }
 
 // lexWhitespace is the state function for lexing whitespace.
+// The first character is already lexed.
 func lexWhitespace(l *lexer) stateFn {
 	for {
 		r := l.next()

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -568,12 +568,12 @@ func lexNumberLiteral(l *lexer) stateFn {
 	for {
 		r := l.next()
 
-		switch r {
+		switch {
 		default:
 			l.backup()
 			return emit()
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'e', '.', '-', '+': // noop
-		case eof:
+		case '0' <= r && r <= '9', r == '.', r == 'e', r == '-', r == '+': // noop
+		case r == eof:
 			return emit()
 		}
 	}

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -163,7 +163,8 @@ func Test_lex(t *testing.T) {
 			input: "{hello+world}",
 			want: []item{
 				mk(itemExpressionOpen, "{"),
-				mkErrorf(`invalid unquoted literal "hello+world"`),
+				mk(itemUnquotedLiteral, "hello"),
+				mkErrorf(`bad character "+" in expression`),
 			},
 		},
 		{


### PR DESCRIPTION
```console
$ benchstat a.txt b.txt      
goos: darwin
goarch: arm64
pkg: go.expect.digital/mf2/parse
cpu: Apple M2 Max
                         │    a.txt     │                b.txt                │
                         │    sec/op    │   sec/op     vs base                │
ComplexMessage_String-12    879.8n ± 1%   894.2n ± 1%   +1.64% (p=0.000 n=10)
Lex-12                     1308.0n ± 1%   974.2n ± 1%  -25.52% (p=0.000 n=10)
Parse-12                    3.058µ ± 0%   2.700µ ± 0%  -11.69% (p=0.000 n=10)
geomean                     1.521µ        1.330µ       -12.56%

                         │    a.txt     │                 b.txt                  │
                         │     B/op     │     B/op      vs base                  │
ComplexMessage_String-12     776.0 ± 0%     776.0 ± 0%        ~ (p=1.000 n=10) ¹
Lex-12                       656.0 ± 0%     112.0 ± 0%  -82.93% (p=0.000 n=10)
Parse-12                   7.242Ki ± 0%   6.711Ki ± 0%   -7.34% (p=0.000 n=10)
geomean                    1.521Ki          842.1       -45.92%
¹ all samples are equal

                         │    a.txt    │                b.txt                 │
                         │  allocs/op  │ allocs/op   vs base                  │
ComplexMessage_String-12    33.00 ± 0%   33.00 ± 0%        ~ (p=1.000 n=10) ¹
Lex-12                     19.000 ± 0%   3.000 ± 0%  -84.21% (p=0.000 n=10)
Parse-12                    53.00 ± 0%   37.00 ± 0%  -30.19% (p=0.000 n=10)
geomean                     32.15        15.42       -52.05%
```