### PR TITLE
use variant keys for particular selector

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -493,23 +493,28 @@ func (e *executer) resolvePreferences(m ast.Matcher, selectors []*ResolvedValue)
 	pref := make([][]string, 0, len(selectors))
 
 	for i := range selectors {
-		var keys []string
+		keys := make([]string, 0, len(m.Variants[i].Keys))
 
 		for _, variant := range m.Variants {
-			for _, vKey := range variant.Keys {
-				// NOTE(mvilks): since collected keys will be compared to the selector,
-				//	we need the keys's raw string value, not the representation of it
-				//  e.g. the `1` should be equal to `|1|`
-				switch key := vKey.(type) {
-				case ast.CatchAllKey:
-					continue
-				case ast.QuotedLiteral:
-					keys = append(keys, string(key))
-				case ast.NameLiteral:
-					keys = append(keys, string(key))
-				case ast.NumberLiteral:
-					keys = append(keys, key.String())
-				}
+			// NOTE(mvilks): since collected keys will be compared to the selector,
+			//	we need the keys's raw string value, not the representation of it
+			//  e.g. the `1` should be equal to `|1|`
+			var key string
+
+			switch v := variant.Keys[i].(type) {
+			case ast.CatchAllKey:
+				continue
+			case ast.QuotedLiteral:
+				key = string(v)
+			case ast.NameLiteral:
+				key = string(v)
+			case ast.NumberLiteral:
+				key = v.String()
+			}
+
+			// add only unique keys
+			if !slices.Contains(keys, key) {
+				keys = append(keys, key)
 			}
 		}
 

--- a/template/template.go
+++ b/template/template.go
@@ -492,8 +492,11 @@ func (e *executer) resolvePreferences(m ast.Matcher, selectors []*ResolvedValue)
 	// Step 2: Resolve Preferences
 	pref := make([][]string, 0, len(selectors))
 
+	// all variants have the same number of keys
+	n := len(m.Variants[0].Keys)
+
 	for i := range selectors {
-		keys := make([]string, 0, len(m.Variants[i].Keys))
+		keys := make([]string, 0, n)
 
 		for _, variant := range m.Variants {
 			// NOTE(mvilks): since collected keys will be compared to the selector,


### PR DESCRIPTION
Currently, ALL variant keys are ALWAYS passed to selectKey().

We only want to pass variant (unique) keys for a particular selector.

```console
$ benchstat a.txt b.txt                       
goos: darwin
goarch: arm64
pkg: go.expect.digital/mf2/template
cpu: Apple M2 Max
                   │    a.txt    │               b.txt                │
                   │   sec/op    │   sec/op     vs base               │
Template_Sprint-12   2.428µ ± 0%   2.333µ ± 0%  -3.91% (p=0.000 n=10)

                   │    a.txt     │                b.txt                │
                   │     B/op     │     B/op      vs base               │
Template_Sprint-12   4.297Ki ± 0%   4.141Ki ± 0%  -3.64% (p=0.000 n=10)

                   │   a.txt    │               b.txt               │
                   │ allocs/op  │ allocs/op   vs base               │
Template_Sprint-12   86.00 ± 0%   82.00 ± 0%  -4.65% (p=0.000 n=10)
```